### PR TITLE
Add Support for RegEx in Transformer

### DIFF
--- a/tasks/modules/transformers.ts
+++ b/tasks/modules/transformers.ts
@@ -61,6 +61,16 @@ function getImports(currentFilePath: string, name: string, targetFiles: string[]
         }
     }
 
+    if (files.length === 0) {//No direct Match
+            var regExFiles = [];
+            _.each(targetFiles, function (fileName) { //Go through all fiels
+                if (fileName.match(new RegExp(name))) {//Convert Name to RegExp
+                    regExFiles.push(fileName);//Push to Array
+                }
+            })
+        regExFiles.sort(); // Sort needed to increase reliability of codegen between runs
+        files = files.concat(regExFiles);
+    }
     return files;
 }
 


### PR DESCRIPTION
I missed this feature in grunt-ts.

Makes it possible to do things like this:

///ts:export=.*Controller.ts